### PR TITLE
adding initial players

### DIFF
--- a/MpsAllocatorSample/Program.cs
+++ b/MpsAllocatorSample/Program.cs
@@ -203,23 +203,16 @@ namespace MpsAllocator
             string region = Console.ReadLine();
             req2.PreferredRegions = new List<string>() {region};
             req2.SessionId = Guid.NewGuid().ToString();
-            // InitialPlayers is the list of the initial players of the game
-            // they might or might not end up connecting to the game
+            // Initial list of players (potentially matchmade) allowed to connect to the game.
+            // This list is passed to the game server when requested (via GSDK) and can be used to validate players connecting to it.
             Console.WriteLine("Type initial players ID, Enter to confirm. Empty string when you're done");
             string id = Console.ReadLine();
-            while(true)
+            while(!string.IsNullOrEmpty(id))
             {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    req2.InitialPlayers ??= new List<string>();
-                    req2.InitialPlayers.Add(id.Trim());
-                    Console.WriteLine($"player with ID {id} was recorded, type the next one. Empty string when you're done");
-                    id = Console.ReadLine();
-                }
-                else
-                {
-                    break;
-                }
+                req2.InitialPlayers ??= new List<string>();
+                req2.InitialPlayers.Add(id.Trim());
+                Console.WriteLine($"player with ID {id} was recorded, type the next one. Empty string when you're done");
+                id = Console.ReadLine();
             } 
             var res = await PlayFabMultiplayerAPI.RequestMultiplayerServerAsync(req2);
             if (res.Error != null)

--- a/MpsAllocatorSample/Program.cs
+++ b/MpsAllocatorSample/Program.cs
@@ -203,6 +203,24 @@ namespace MpsAllocator
             string region = Console.ReadLine();
             req2.PreferredRegions = new List<string>() {region};
             req2.SessionId = Guid.NewGuid().ToString();
+            // InitialPlayers is the list of the initial players of the game
+            // they might or might not end up connecting to the game
+            Console.WriteLine("Type initial players ID, Enter to confirm. Empty string when you're done");
+            string id = Console.ReadLine();
+            while(true)
+            {
+                if (!string.IsNullOrEmpty(id))
+                {
+                    req2.InitialPlayers ??= new List<string>();
+                    req2.InitialPlayers.Add(id.Trim());
+                    Console.WriteLine($"player with ID {id} was recorded, type the next one. Empty string when you're done");
+                    id = Console.ReadLine();
+                }
+                else
+                {
+                    break;
+                }
+            } 
             var res = await PlayFabMultiplayerAPI.RequestMultiplayerServerAsync(req2);
             if (res.Error != null)
             {

--- a/wrappingGsdk/wrapper/Program.cs
+++ b/wrappingGsdk/wrapper/Program.cs
@@ -56,6 +56,16 @@ namespace wrapper
                 // After allocation, we can grab the session cookie from the config
                 IDictionary<string, string> activeConfig = GameserverSDK.getConfigSettings();
 
+                var connectedPlayers = new List<ConnectedPlayer>();
+                // initial players includes the list of the players that are allowed to connect to the game
+                // they might or might not end up connecting
+                // in this sample we're nevertheless adding them to the list 
+                foreach (var player in GameserverSDK.GetInitialPlayers())
+                {
+                    connectedPlayers.Add(new ConnectedPlayer(player));
+                }
+                GameserverSDK.UpdateConnectedPlayers(connectedPlayers);
+                
                 if (activeConfig.TryGetValue(GameserverSDK.SessionCookieKey, out string sessionCookie))
                 {
                     LogMessage($"The session cookie from the allocation call is: {sessionCookie}");


### PR DESCRIPTION
Adding initial players implementation.
- In wrappingGsdk, we're adding them to the ConnectedPlayers list
- in  MpsAllocatorSample, we're extending the RequestMultiplayerServer API call to accept a list of strings representing the initial player IDs 