### PR TITLE
New Matchmake sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,3 +322,6 @@ gradle-app.setting
 ## End Android
 
 drop
+
+.leu
+launchSettings.json

--- a/MatchmakeSample/MatchmakeSample.sln
+++ b/MatchmakeSample/MatchmakeSample.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MatchmakeSample", "MatchmakeSample\MatchmakeSample.csproj", "{C14085C7-84CC-45E8-BEE3-8B34E9B46BFC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C14085C7-84CC-45E8-BEE3-8B34E9B46BFC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C14085C7-84CC-45E8-BEE3-8B34E9B46BFC}.Debug|x64.Build.0 = Debug|Any CPU
+		{C14085C7-84CC-45E8-BEE3-8B34E9B46BFC}.Release|x64.ActiveCfg = Release|Any CPU
+		{C14085C7-84CC-45E8-BEE3-8B34E9B46BFC}.Release|x64.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E2B21EE1-796D-4248-A686-420CC9475203}
+	EndGlobalSection
+EndGlobal

--- a/MatchmakeSample/MatchmakeSample/MatchmakeSample.csproj
+++ b/MatchmakeSample/MatchmakeSample/MatchmakeSample.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="PlayFabAllSDK" Version="1.66.200218" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+        <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19577.1" />
+    </ItemGroup>
+
+</Project>

--- a/MatchmakeSample/MatchmakeSample/Program.cs
+++ b/MatchmakeSample/MatchmakeSample/Program.cs
@@ -1,0 +1,178 @@
+﻿using PlayFab;
+using PlayFab.ClientModels;
+using PlayFab.MultiplayerModels;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace WindowsRunnerCSharpClient
+{
+    /// <summary>
+    ///   Simple executable that integrates with PlayFab's SDK.
+    ///   It allocates a game server and makes an http request to that game server
+    /// </summary>
+    public class Program
+    {
+        private static readonly PlayFabApiSettings settings = new PlayFabApiSettings();
+        private static readonly List<Player> players = new List<Player>();
+
+        public static Task Main(string[] args)
+        {
+            RootCommand rootCommand = RootCommandConfiguration.GenerateCommand(Run);
+
+            return rootCommand.InvokeAsync(args);
+        }
+
+        private static async Task Run(string titleId, int numPlayers, string mmQueueName)
+        {
+            settings.TitleId = titleId;
+
+            for (int i = 0; i < numPlayers; i++)
+            {
+                Player eachPlayer = new Player(Guid.NewGuid().ToString(), settings);
+                await Login(eachPlayer);
+                players.Add(eachPlayer);
+            }
+
+            VerifyNumPlayers(2, "matchmaking");
+            foreach (Player eachPlayer in players)
+            {
+                await CreateMatchmakeTicket(eachPlayer, mmQueueName);
+            }
+            bool success = true;
+            foreach (Player eachPlayer in players)
+            {
+                success &= await WaitForTicket(eachPlayer, mmQueueName);
+            }
+            VerifySuccess(success, "Matchmake-All Players");
+            foreach (Player eachPlayer in players)
+            {
+                await GetFinalMatch(eachPlayer, mmQueueName);
+            }
+        }
+
+        private static void VerifyNumPlayers(int numRequired, string feature)
+        {
+            if (players.Count < numRequired)
+            {
+                Console.WriteLine($"Need at least {numRequired} player(s) to test {feature}, playerCount: {players.Count}");
+                throw new Exception($"Need at least {numRequired} player(s) to test {feature}, playerCount: {players.Count}");
+            }
+        }
+
+        private static TResult VerifyPlayFabCall<TResult>(PlayFabResult<TResult> playFabResult, string throwMsg) where TResult : PlayFab.Internal.PlayFabResultCommon
+        {
+            if (playFabResult.Error != null)
+            {
+                Console.WriteLine(playFabResult.Error.GenerateErrorReport());
+                throw new Exception($"{throwMsg} HttpStatus={playFabResult.Error.HttpStatus}");
+            }
+            return playFabResult.Result;
+        }
+
+        private static void VerifySuccess(bool success, string eventName)
+        {
+            if (success)
+            {
+                Console.WriteLine($"{eventName} succeeded.");
+            }
+            else
+            {
+                Console.WriteLine($"{eventName} did not succeed.");
+                throw new Exception($"{eventName} did not succeed.");
+            }
+        }
+
+        private static async Task Login(Player player)
+        {
+            var loginRequest = new LoginWithCustomIDRequest()
+            {
+                CustomId = player.customId,
+                CreateAccount = true
+            };
+            PlayFabResult<LoginResult> login = await player.clientApi.LoginWithCustomIDAsync(loginRequest);
+            LoginResult loginResult = VerifyPlayFabCall(login, "Login failed");
+            Console.WriteLine($"Logged in player {login.Result.PlayFabId}, CustomId={loginRequest.CustomId}");
+        }
+
+        private static async Task CreateMatchmakeTicket(Player player, string mmQueueName)
+        {
+            var createRequest = new CreateMatchmakingTicketRequest
+            {
+                QueueName = mmQueueName,
+                GiveUpAfterSeconds = 15,
+                Creator = new MatchmakingPlayer { Entity = new PlayFab.MultiplayerModels.EntityKey { Id = player.context.EntityId, Type = player.context.EntityType } } // Why isn't this just the caller?
+            };
+            PlayFabResult<CreateMatchmakingTicketResult> ticketResult = await player.mpApi.CreateMatchmakingTicketAsync(createRequest);
+            CreateMatchmakingTicketResult ticket = VerifyPlayFabCall(ticketResult, "Failed to create matchmake ticket");
+            player.mmTicketId = ticket.TicketId;
+        }
+
+        private static async Task<bool> WaitForTicket(Player player, string mmQueueName)
+        {
+            var getTicketRequest = new GetMatchmakingTicketRequest
+            {
+                TicketId = player.mmTicketId,
+                QueueName = mmQueueName // Why isn't this discoverable from the ticketId?
+            };
+
+            bool success = false;
+            for (int i = 0; i < 10; i++)
+            {
+                PlayFabResult<GetMatchmakingTicketResult> ticketResult = await player.mpApi.GetMatchmakingTicketAsync(getTicketRequest);
+                GetMatchmakingTicketResult ticket = VerifyPlayFabCall(ticketResult, "Matchmake ticket poll failed.");
+                if (ticket.Status == "Matched")
+                {
+                    player.mmMatchId = ticket.MatchId;
+                    player.ticket = ticket;
+                    success = true;
+                    break;
+                }
+                System.Threading.Thread.Sleep(6000);
+                // "WaitingForMatch", "Matched"
+            }
+            VerifySuccess(success, $"Matchmake for {player.context.PlayFabId}");
+            return success;
+        }
+
+        private static async Task<GetMatchResult> GetFinalMatch(Player player, string mmQueueName)
+        {
+            var getRequest = new GetMatchRequest
+            {
+                QueueName = mmQueueName,
+                MatchId = player.mmMatchId
+            };
+            PlayFabResult<GetMatchResult> ticketResult = await player.mpApi.GetMatchAsync(getRequest);
+            GetMatchResult match = VerifyPlayFabCall(ticketResult, "Failed to get final matchmake ticket");
+            player.match = match;
+            Console.WriteLine($"{player.context.PlayFabId} matched: {match.MatchId}");
+            return match;
+        }
+    }
+
+    public class Player
+    {
+        public readonly string customId;
+        public readonly HttpClient httpClient;
+        public readonly PlayFabAuthenticationContext context;
+        public readonly PlayFabClientInstanceAPI clientApi;
+        public readonly PlayFabMultiplayerInstanceAPI mpApi;
+
+        public string mmTicketId;
+        public string mmMatchId;
+        public GetMatchmakingTicketResult ticket;
+        public GetMatchResult match;
+
+        public Player(string customId, PlayFabApiSettings settings)
+        {
+            this.customId = customId;
+            httpClient = new HttpClient();
+            context = new PlayFabAuthenticationContext();
+            clientApi = new PlayFabClientInstanceAPI(settings, context);
+            mpApi = new PlayFabMultiplayerInstanceAPI(settings, context);
+        }
+    }
+}

--- a/MatchmakeSample/MatchmakeSample/RootCommandConfiguration.cs
+++ b/MatchmakeSample/MatchmakeSample/RootCommandConfiguration.cs
@@ -1,0 +1,42 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+
+namespace WindowsRunnerCSharpClient
+{
+    /// <summary>
+    /// Used to create and run the root command for VmAgent.  
+    /// </summary>
+    public static class RootCommandConfiguration
+    {
+        public static RootCommand GenerateCommand(Func<string, int, string, Task> onInvoke)
+        {
+            var rootCommand = new RootCommand()
+            {
+                new Option("--titleId",
+                    "Your PlayFab titleId (Hex)")
+                {
+                    Argument = new Argument<string>(),
+                    Required = true
+                },
+                new Option("--numPlayers",
+                    "Number of players to create")
+                {
+                    Argument = new Argument<int>(),
+                    Required = true
+                },
+                new Option("--mmQueueName",
+                    "Name of Matchmaking Queue to join")
+                {
+                    Argument = new Argument<string>(),
+                    Required = true
+                },
+            };
+
+            rootCommand.Handler = CommandHandler.Create(onInvoke);
+            
+            return rootCommand;
+        }
+    }
+}

--- a/MatchmakeSample/README.md
+++ b/MatchmakeSample/README.md
@@ -8,7 +8,7 @@
 * PlayFab Title with Matchmaking enabled
 
 ## Overview
-MatchmakeSample is a sample executable that integrates with PlayFab's Matchmaking system. It logs in a configurable number of clients and attempts to matchmake them together, following the steps described in the (Single user ticket matchmaking)[https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/matchmaking/quickstart#single-user-ticket-matchmaking] sample
+MatchmakeSample is a sample executable that integrates with PlayFab's Matchmaking system. It logs in a configurable number of clients and attempts to matchmake them together, following the steps described in the [Single user ticket matchmaking](https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/matchmaking/quickstart#single-user-ticket-matchmaking) sample
 
 ## Getting Started Guide
 

--- a/MatchmakeSample/README.md
+++ b/MatchmakeSample/README.md
@@ -8,8 +8,7 @@
 * PlayFab Title with Matchmaking enabled
 
 ## Overview
-MatchmakeSample is a sample executable that integrates with PlayFab's Matchmaking system. It logs in a configurable number of clients and attempts to matchmake them together.
-
+MatchmakeSample is a sample executable that integrates with PlayFab's Matchmaking system. It logs in a configurable number of clients and attempts to matchmake them together, following the steps described in the (Single user ticket matchmaking)[https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/matchmaking/quickstart#single-user-ticket-matchmaking] sample
 
 ## Getting Started Guide
 

--- a/MatchmakeSample/README.md
+++ b/MatchmakeSample/README.md
@@ -1,0 +1,38 @@
+# MatchmakeSample
+
+## Dependencies
+* .Net Core 3.1
+
+## Prerequisites
+* Understanding of C#
+* PlayFab Title with Matchmaking enabled
+
+## Overview
+MatchmakeSample is a sample executable that integrates with PlayFab's Matchmaking system. It logs in a configurable number of clients and attempts to matchmake them together.
+
+
+## Getting Started Guide
+
+### Running this sample locally
+1. Get your PlayFab TitleId and a Matchmake queue name for your title
+1. Build the solution, navigate to the binary output folder, and find the MatchmakeSample.dll output file
+1. Run the MatchmakeSample with the command line:
+    1. Depending on the number of players chosen and your queue settings, they may be matched into one or multiple groups
+
+```dotnet MatchmakeSample.dll --titleId <Your TitleId> --numPlayers 10 --mmQueueName <Name of Matchmake queue for your title>```
+
+With no parameters, this command will show these options:
+```
+Option '--titleId' is required.
+Option '--numPlayers' is required.
+Option '--mmQueueName' is required.
+
+Usage:
+  MatchmakeSample [options]
+
+Options:
+  --titleId <titleid>            Your PlayFab titleId (Hex)
+  --numPlayers <numplayers>      Number of players to create
+  --mmQueueName <mmqueuename>    Name of Matchmaking Queue to join
+  --version                      Display version information
+```

--- a/MatchmakeSample/README.md
+++ b/MatchmakeSample/README.md
@@ -8,7 +8,7 @@
 * PlayFab Title with Matchmaking enabled
 
 ## Overview
-MatchmakeSample is a sample executable that integrates with PlayFab's Matchmaking system. It logs in a configurable number of clients and attempts to matchmake them together, following the steps described in the [Single user ticket matchmaking](https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/matchmaking/quickstart#single-user-ticket-matchmaking) sample
+MatchmakeSample is a sample executable that integrates with PlayFab's Matchmaking system. It logs in a configurable number of clients and attempts to matchmake them together, following the steps described in the [Single user ticket matchmaking](https://docs.microsoft.com/gaming/playfab/features/multiplayer/matchmaking/quickstart#single-user-ticket-matchmaking) sample.
 
 ## Getting Started Guide
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ MPS service uses Docker containers to schedule game servers. You can see some **
 
 ## Matchmake Sample
 
-The Matchmake sample logs in a configurable number of clients and attempts to matchmake them together, following the steps described in the [Single user ticket matchmaking](https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/matchmaking/quickstart#single-user-ticket-matchmaking) sample.
+The Matchmake sample logs in a configurable number of clients and attempts to matchmake them together, following the steps described in the [Single user ticket matchmaking](https://docs.microsoft.com/gaming/playfab/features/multiplayer/matchmaking/quickstart#single-user-ticket-matchmaking) sample.
 
 ## Community samples
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ This is a simple .NET Core console app that lets use easily see your MPS Builds/
 
 MPS service uses Docker containers to schedule game servers. You can see some **advanced** debugging/diagnosing instructions [here](./Debugging.md).
 
+## Matchmake Sample
+
+The Matchmake sample logs in a configurable number of clients and attempts to matchmake them together, following the steps described in the [Single user ticket matchmaking](https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/matchmaking/quickstart#single-user-ticket-matchmaking) sample.
+
 ## Community samples
 
 Here you can find a list of samples and utilities created and supported by our community. [Let us know](https://github.com/PlayFab/gsdkSamples/issues) if you have created a sample yourself and would like to have it mentioned here.


### PR DESCRIPTION
**New Matchmake sample cloned and modified from the WindowsRunnerCSharp sample**
1. Pick a title, queue, and number of players.
2. Logs in all players. Begins a matchmake with every player, and then displays matchmake results.
3. New Matchmake Readme

**Back ported some refactors to the WindowsRunnerCSharp sample:**
1. Refactored each step into its own function
2. Player-centered approach (makes it easier to define/use multiple players in a single app)
3. Removed PlayFabId definable from command line (makes it hard to define multi-player, and not easily compatible with other player refactors)
4. Some verification and util functions from Matchmake Sample
5. Updated Readme

Set some additional unwanted files in .gitignore