### PR TITLE
renaming MockAgent to LocalMultiplayerAgent

### DIFF
--- a/Debugging.md
+++ b/Debugging.md
@@ -81,15 +81,15 @@ You can follow the steps in [this article](https://docs.microsoft.com/en-us/gami
 In these cases, you might see an output similar as this:
 
 ```
-info: MockPlayFabVmAgent[0]
+info: PlayfabMultiplayerAgent[0]
       Waiting for heartbeats from the game server.....
-info: MockPlayFabVmAgent[0]
+info: PlayfabMultiplayerAgent[0]
       Container 4179fa451214251a45d1a8e8338203a9ff05dc6ec1231c50e1f81f5508b3e1c8 exited with exit code 1.
-info: MockPlayFabVmAgent[0]
+info: PlayfabMultiplayerAgent[0]
       Collecting logs for container 4179fa451214251a45d1a8e8338203a9ff05dc6ec1231c50e1f81f5508b3e1c8.
-info: MockPlayFabVmAgent[0]
+info: PlayfabMultiplayerAgent[0]
       Copying log file C:\ProgramData\Docker\containers\4179fa451214251a45d1a8e8338203a9ff05dc6ec1231c50e1f81f5508b3e1c8\4179fa451214251a45d1a8e8338203a9ff05dc6ec1231c50e1f81f5508b3e1c8-json.log for container 4179fa451214251a45d1a8e8338203a9ff05dc6ec1231c50e1f81f5508b3e1c8 to D:\playfab\PlayFabVmAgentOutput\2020-09-29T01-42-01\GameLogs\032e7357-1956-4a60-9682-ca462cc3ea12\PF_ConsoleLogs.txt.
-info: MockPlayFabVmAgent[0]
+info: PlayfabMultiplayerAgent[0]
       Deleting container 4179fa451214251a45d1a8e8338203a9ff05dc6ec1231c50e1f81f5508b3e1c8.
 ```
 

--- a/UnityMirror/README.md
+++ b/UnityMirror/README.md
@@ -54,8 +54,8 @@ This sample uses [Mirror](https://github.com/vis2k/Mirror), the community replac
     - Within GamePort, set Number to 7777 and Protocol to TCP. Also make a note of the external port number, called NodePort
 1. In PowerShell
     - Run the LocalMultiplayerAgentSetup file in *agentfolder/setup.ps1* (you may need to open Powershell with admin permissions for this purpose). If you get a signing violation, you may need to run `Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process`.
-    - Run the Local Multiplayer Agent located in *agentfolder/MockVmAgent.exe*.
-1. You will see the mock agent report state. Wait for reports to go from `Waiting for heartbeats from the game server.....` to `CurrentGameState: StandingBy` to `CurrentGameState: Active` then proceed to the next step
+    - Run the Local Multiplayer Agent located in *agentfolder/PlayfabMultiplayerAgent.exe*.
+1. You will see the PlayfabMultiplayerAgent report state. Wait for reports to go from `Waiting for heartbeats from the game server.....` to `CurrentGameState: StandingBy` to `CurrentGameState: Active` then proceed to the next step
 
 ### Running the client
 1. With the server running, open the UnityClient project in the Unity IDE.


### PR DESCRIPTION
As part of [OSS-ing LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/), this documentation PR renames the executable to its new name.