### PR TITLE
instructions for unity fix

### DIFF
--- a/UnityMirror/README.md
+++ b/UnityMirror/README.md
@@ -235,3 +235,7 @@ CMD ["/game/UnityServer.x86_64", "-nographics", "-batchmode", "-logfile"]
 ```
 
 - You're now ready to build your image! If you want to develop locally, you can use `docker build -t myregistry.io/mygame:0.1 .` to build your game and test it with [LocalMultiplayerAgent](https://github.com/PlayFab/LocalMultiplayerAgent). Or, you can get the proper PlayFab container registry credentials (using [this](https://docs.microsoft.com/en-us/rest/api/playfab/multiplayer/multiplayerserver/getcontainerregistrycredentials?view=playfab-rest) API call or from the Builds page on PlayFab web site). Once you do that, you can `docker build/tag/push` your container image to the PlayFab container registry and spin game servers running it.
+
+### Heartbeats are failing when I run in container mode (no heartbeat error), what should I do?
+
+GSDK sends game server heartbeats to the PlayFab VmAgent process (which is in the same VM as the game server) using plain HTTP calls. Unity disallows that by default, but you can enable it in "project settings > player > other settings > allow downloads over http".


### PR DESCRIPTION
Providing a workaround for GSDK heartbeat failures in Unity in container mode.